### PR TITLE
Add NGINX container to proxy Grafana

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Rebuild using 9.0.0-beta3 (#9)
 - Update Requirements to Grafana 8.5.0 (#12)
+- Add NGINX container to proxy Grafana (#10)
 
 ## 1.3.0 (2022-05-01)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,3 +19,15 @@ services:
       - ./provisioning:/etc/grafana/provisioning
       # Uncomment to preserve Grafana configuration
       # - ./data:/var/lib/grafana
+
+  nginx:
+    container_name: nginx
+    build: ./nginx
+    restart: always
+    environment:
+      - GRAFANA_HOST=host.docker.internal
+    ports:
+      - 80:80/tcp
+      - 443:443/tcp
+    depends_on:
+      - grafana

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,20 @@
+FROM nginx:stable-alpine
+
+## Environment
+ENV API_HOST=localhost
+ENV API_PORT=3001
+ENV GRAFANA_HOST=localhost
+ENV GRAFANA_PORT=3000
+ENV GRAFANA_SSL=/C=US/ST=Florida/L=Tampa/O=Volkov Labs/OU=Technology/CN=localhost/
+
+## Generate certificate
+RUN apk add --update openssl && \
+    rm -rf /var/cache/apk/*
+RUN openssl req -x509 -out /etc/nginx/ssl.crt -keyout /etc/nginx/ssl.key -newkey rsa:4096 -nodes -sha256 -subj ${GRAFANA_SSL}
+    
+## Copy configuration
+COPY default.conf /etc/nginx/templates/default.conf.template
+COPY proxy.conf /etc/nginx/conf.d/proxy.conf
+COPY http_headers.conf /etc/nginx/conf.d/http_headers.conf
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,34 @@
+server {
+  listen 80;
+
+  include /etc/nginx/conf.d/http_headers.conf;
+
+  location / {
+    proxy_pass http://${GRAFANA_HOST}:${GRAFANA_PORT};
+    include /etc/nginx/conf.d/proxy.conf;
+  }
+}
+
+server {
+  listen 443 ssl;
+
+  include /etc/nginx/conf.d/http_headers.conf;
+
+  ssl_certificate /etc/nginx/ssl.crt;
+  ssl_certificate_key /etc/nginx/ssl.key;
+
+  ssl_session_cache builtin:1000 shared:SSL:10m;
+  ssl_protocols TLSv1.2;
+  ssl_ciphers EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH;
+  ssl_prefer_server_ciphers on;
+
+  location / {
+    proxy_pass http://${GRAFANA_HOST}:${GRAFANA_PORT};
+    include /etc/nginx/conf.d/proxy.conf;
+  }
+
+  #location /api/XXX {
+  #  proxy_pass http://${API_HOST}:${API_PORT};
+  #  include /etc/nginx/conf.d/proxy.conf;
+  #}
+}

--- a/nginx/http_headers.conf
+++ b/nginx/http_headers.conf
@@ -1,0 +1,7 @@
+add_header X-Frame-Options "SAMEORIGIN";
+add_header X-Content-Type-Options "nosniff";
+add_header X-DNS-Prefetch-Control "off";
+add_header X-Download-Options "noopen";
+add_header Referrer-Policy "no-referrer";
+add_header Strict-Transport-Security "max-age=15768000;";
+add_header Cache-Control "private";

--- a/nginx/proxy.conf
+++ b/nginx/proxy.conf
@@ -1,0 +1,5 @@
+proxy_http_version 1.1;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header Connection 'upgrade';
+proxy_set_header Host $host;
+proxy_cache_bypass $http_upgrade;


### PR DESCRIPTION
We always recommend using NGINX in front of Grafana.

Resolves #10 